### PR TITLE
Allow selecting the compiler

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,6 +34,8 @@ with `cabal new-build` when I am not using `nix`. I suspect that the problem is
 that the different instantiations of the same indefinite module are somehow
 clobbering one another.
 
+The compiler can be selected with an argument like `--argstr compiler ghc844`.
+
 ## Original (Solved) Problem Description
 
 The repository is a minimal example that reproduces an error I encounter when

--- a/release.nix
+++ b/release.nix
@@ -1,9 +1,10 @@
+{ compiler ?  "ghc844" }:
 let
   config = {
     packageOverrides = pkgs: rec {
       haskell = pkgs.haskell // {
         packages = pkgs.haskell.packages // {
-          ghc841 = pkgs.haskell.packages.ghc841.override {
+          ${compiler} = pkgs.haskell.packages.${compiler}.override {
             overrides = haskellPackagesNew: haskellPackagesOld: rec {
               nix-backpack-problem =
                 haskellPackagesNew.callPackage ./default.nix { };
@@ -26,4 +27,4 @@ let
   pkgs = import <nixpkgs> { inherit config; };
 
 in
-  pkgs.haskell.packages.ghc841.nix-backpack-problem
+  pkgs.haskell.packages.${compiler}.nix-backpack-problem


### PR DESCRIPTION
Also change the default to 844 as 841 is no longer present in nixpkgs